### PR TITLE
Adds support for multiple source types

### DIFF
--- a/studio-drm-standalone/src/receiver/receiver.js
+++ b/studio-drm-standalone/src/receiver/receiver.js
@@ -19,13 +19,17 @@
         }
         if (customData){
             if (customData["laurl"]){
-                token = customData["token"];
-                laurl = customData["laurl"];
+                if(customData["token"]){
+                    token = customData["token"];
+                    laurl = customData["laurl"];
+                }
             }
             else if (customData["drm"]["widevine"]["url"]){
                 widevine = customData["drm"]["widevine"];
+                if (widevine["url"]){
                 laurl = widevine["url"];
                 token = widevine["headers"][0]["value"];
+                }
             }
         }
         playerManager.setPlaybackConfig(createPlaybackConfig(playerManager));

--- a/studio-drm-with-jw-platform/src/receiver/receiver.js
+++ b/studio-drm-with-jw-platform/src/receiver/receiver.js
@@ -1,13 +1,31 @@
 (() => {
     const context = cast.framework.CastReceiverContext.getInstance();
     const playerManager = context.getPlayerManager();
-
     var laurl;
 
     // Wait until the cast player is loaded, get the laurl from the media request and use it in the player config
     playerManager.setMessageInterceptor(cast.framework.messages.MessageType.LOAD, loadRequestData => {
       let customData = loadRequestData.media.customData;
-      laurl = customData["laurl"];
+      // Check all content source fields for asset URL or ID
+      let source = loadRequestData.media.contentUrl || loadRequestData.media.entity || loadRequestData.media.contentId;
+      if (!source || source == ""){
+        let error = new cast.framework.messages.ErrorData(
+          cast.framework.messages.ErrorType.LOAD_FAILED
+        );
+        error.reason = cast.framework.messages.ErrorReason.INVALID_REQUEST;
+        return error;
+      }
+
+      loadRequestData.media.contentUrl = source;
+
+      if (customData){
+        if (customData["laurl"]){
+          laurl = customData["laurl"];
+        }
+        else if (customData["drm"]["widevine"]["url"]){
+          laurl = customData["drm"]["widevine"]["url"];
+        }
+      }
       playerManager.setPlaybackConfig(createPlaybackConfig(playerManager));
       return loadRequestData;
     }


### PR DESCRIPTION
iOS devices send the source URL in a different form to the JWP web player. This adds support for multiple source types, and for native mobile apps to send custom data directly to the receiver